### PR TITLE
fix: remove kubernetes_version default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ module "sks" {
   name = "test"
   zone = "de-fra-1"
 
+  kubernetes_version = "1.21.3"
+
   nodepools = {
     "router" = {
       instance_type = "medium"

--- a/variables.tf
+++ b/variables.tf
@@ -9,8 +9,8 @@ variable "zone" {
 }
 
 variable "kubernetes_version" {
-  type    = string
-  default = "1.20.2"
+  description = "The kubernetes version to use. See the Exoscale documentation or portal for possible choices."
+  type        = string
 }
 
 variable "nodepools" {


### PR DESCRIPTION
The available k8s versions seem to change frequently so it doesn't make sense
to have a default value here. Users should always check the supported versions.

Fixes #1