### PR TITLE
feat: make nodeport ports world accessibility optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,8 @@ resource "exoscale_security_group" "this" {
 }
 
 resource "exoscale_security_group_rule" "nodeport_services" {
+  count = var.node_ports_world_accessible ? 1 : 0
+
   security_group_id = exoscale_security_group.this.id
   type              = "INGRESS"
   protocol          = "TCP"

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,9 @@ variable "wait_for_cluster_interpreter" {
   type        = list(string)
   default     = ["/bin/sh", "-c"]
 }
+
+variable "node_ports_world_accessible" {
+  description = "Create a security group rule that allows world access to to NodePort services."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This rule is useful when the IP of the load balancer is not known but is not
wanted in all situations.