### PR TITLE
Install exo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A terraform module to create a managed Kubernetes cluster on Exoscale SKS.
 
+Forked from camptocamp/terraform-exoscale-sks
+
 This module creates an SKS cluster with one or more node pools. It creates one security group for all instances with the minimum rules recommended in the exoscale documentation. It also creates one anti-affinity group for each node pool. It then automatically retrieves the kubeconfig that allows access to the cluster.
 
 
@@ -9,13 +11,13 @@ This module creates an SKS cluster with one or more node pools. It creates one s
 
 ```hcl
 module "sks" {
-  source  = "camptocamp/sks/exoscale"
+  source  = "Kosmas/sks/exoscale"
   version = "0.3.1"
 
   name = "test"
   zone = "de-fra-1"
 
-  kubernetes_version = "1.21.3"
+  kubernetes_version = "1.22.4"
 
   nodepools = {
     "router" = {

--- a/kubeconfig.sh
+++ b/kubeconfig.sh
@@ -4,6 +4,6 @@ set -e
 
 eval "$(jq -r '@sh "CLUSTER_ID=\(.cluster_id) ZONE=\(.zone)"')"
 
-kubeconfig=$(exo compute sks kubeconfig "$CLUSTER_ID" kube-admin --group system:masters --zone "$ZONE")
+kubeconfig=$(exo sks kubeconfig "$CLUSTER_ID" kube-admin --group system:masters --zone "$ZONE")
 
 jq -M -n --arg kubeconfig "$kubeconfig" '{"kubeconfig":$kubeconfig}'

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,15 @@ resource "exoscale_sks_nodepool" "this" {
   private_network_ids     = lookup(each.value, "private_network_ids", [])
 }
 
+resource "null_resource" "install_exo" {
+  provisioner "local-exec" {
+    command = <<EOH
+curl -o exo https://github.com/exoscale/cli/releases/download/v1.49.1/exoscale-cli_1.49.1_linux_amd64.tar.gz
+chmod 0755 exo
+EOH
+  }
+}
+
 resource "null_resource" "wait_for_cluster" {
   depends_on = [
     exoscale_sks_cluster.this,
@@ -76,6 +85,10 @@ resource "null_resource" "wait_for_cluster" {
 }
 
 data "external" "kubeconfig" {
+  depends_on = [
+    null_resource.install_exo,
+  ]
+
   program = ["sh", "${path.module}/kubeconfig.sh"]
 
   query = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,16 +1,16 @@
 terraform {
   required_providers {
     exoscale = {
-      source  = "exoscale/exoscale"
-      version = "~> 0.22"
+      source    = "exoscale/exoscale"
+      version   = "~> 0.29.0"
     }
     external = {
-      source  = "hashicorp/external"
-      version = "~> 2.0"
+      source    = "hashicorp/external"
+      version   = "~> 2.1.1"
     }
     null = {
-      source  = "hashicorp/null"
-      version = "~> 3.0"
+      source    = "hashicorp/null"
+      version   = "~> 3.1.0"
     }
   }
 }


### PR DESCRIPTION
Hi,

It seems that when using Terraform's remote state (Terraform Cloud) the exo client also needs to be installed.
Without the installation I get the following error:

│ Error: failed to execute "sh": .terraform/modules/sks/kubeconfig.sh: 7: .terraform/modules/sks/kubeconfig.sh: exo: not found

Adding this does not produce any errors.
Maybe there is another or better way to ensure that exo is installed?