### PR TITLE
Add exo installation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,15 @@ resource "exoscale_sks_nodepool" "this" {
   private_network_ids     = lookup(each.value, "private_network_ids", [])
 }
 
+resource "null_resource" "install_exo" {
+  provisioner "local-exec" {
+    command = <<EOH
+curl -o exo https://github.com/exoscale/cli/releases/download/v1.49.1/exoscale-cli_1.49.1_linux_amd64.tar.gz
+chmod 0755 exo
+EOH
+  }
+}
+
 resource "null_resource" "wait_for_cluster" {
   depends_on = [
     exoscale_sks_cluster.this,
@@ -76,6 +85,10 @@ resource "null_resource" "wait_for_cluster" {
 }
 
 data "external" "kubeconfig" {
+  depends_on = [
+    null_resource.install_exo,
+  ]
+
   program = ["sh", "${path.module}/kubeconfig.sh"]
 
   query = {


### PR DESCRIPTION
Hi,

It seems that when using Terraform's remote state (Terraform Cloud) the exo client also needs to be installed.
Without the installation I get the following error:

│ Error: failed to execute "sh": .terraform/modules/sks/kubeconfig.sh: 7: .terraform/modules/sks/kubeconfig.sh: exo: not found

Adding this does not produce any errors.
Maybe there is another or better way to ensure that exo is installed?