### PR TITLE
Fix nodepool labels and taints creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,13 +50,13 @@ resource "exoscale_sks_nodepool" "this" {
   zone            = var.zone
   cluster_id      = exoscale_sks_cluster.this.id
   name            = each.key
-  description     = lookup(each.value, "description", "")
+  description     = each.value.description != null ? each.value.description : ""
   instance_type   = each.value.instance_type
-  instance_prefix = lookup(each.value, "instance_prefix", "pool")
-  disk_size       = lookup(each.value, "disk_size", "50")
+  instance_prefix = each.value.instance_prefix != null ? each.value.instance_prefix : "pool"
+  disk_size       = each.value.disk_size != null ? each.value.disk_size : "50"
   size            = each.value.size
-  labels          = lookup(each.value, "labels", {})
-  taints          = lookup(each.value, "taints", {})
+  labels          = each.value.labels != null ? each.value.labels : {}
+  taints          = each.value.taints != null ? each.value.taints : {}
 
   anti_affinity_group_ids = [exoscale_affinity.this[each.key].id]
   security_group_ids      = [exoscale_security_group.this.id]

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,6 @@
+terraform {
+  experiments = [module_variable_optional_attrs]
+}
 variable "name" {
   description = "The name of the SKS cluster."
   type        = string
@@ -15,7 +18,16 @@ variable "kubernetes_version" {
 
 variable "nodepools" {
   description = "The SKS node pools to create."
-  type        = map(any)
+  type = map(object({
+      instance_type      = string
+      size               = number
+      description        = optional(string)
+      instance_prefix    = optional(string)
+      disk_size          = optional(string)
+      private_network_ids = optional(list(string))
+      labels = optional(map(any))
+      taints = optional(map(any))
+  }))
 }
 
 variable "wait_for_cluster_cmd" {


### PR DESCRIPTION
Hi, 

this PR fixes #15 and makes it possible to add labels and taints to nodepools.

Example output with this PR:

```
  # module.sks.exoscale_sks_nodepool.this["longhorn"] will be updated in-place
  ~ resource "exoscale_sks_nodepool" "this" {
      + description             = "Longhorn Nodes, not to be autoscaled"
      ~ disk_size               = 50 -> 1000
        id                      = "08da5bfa-9469-4481-b37d-f24d8c3b19b2"
      ~ labels                  = {
          + "node.longhorn.io/create-default-disk" = "true"
        }
        name                    = "longhorn"
        # (12 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Without it, this is not possible at all.
