### PR TITLE
Possibility to disable the Cloud Controller Manager and metrics server

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 resource "exoscale_sks_cluster" "this" {
-  zone    = var.zone
-  name    = var.name
-  version = var.kubernetes_version
+  zone         = var.zone
+  name         = var.name
+  version      = var.kubernetes_version
+  exoscale_ccm = var.exoscale_ccm
 }
 
 resource "exoscale_affinity" "this" {

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,9 @@
 resource "exoscale_sks_cluster" "this" {
-  zone         = var.zone
-  name         = var.name
-  version      = var.kubernetes_version
-  exoscale_ccm = var.exoscale_ccm
+  zone           = var.zone
+  name           = var.name
+  version        = var.kubernetes_version
+  exoscale_ccm   = var.exoscale_ccm
+  metrics_server = var.metrics_server
 }
 
 resource "exoscale_affinity" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "kubernetes_version" {
   type        = string
 }
 
+variable "exoscale_ccm" {
+  description = "Deploy the Exoscale Cloud Controller Manager in the control plane. Default to true."
+  type        = string
+  default     = true
+}
+
 variable "nodepools" {
   description = "The SKS node pools to create."
   type        = map(any)

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,12 @@ variable "exoscale_ccm" {
   default     = true
 }
 
+variable "metrics_server" {
+  description = "Deploy the Metrics server Default to true."
+  type        = string
+  default     = true
+}
+
 variable "nodepools" {
   description = "The SKS node pools to create."
   type        = map(any)


### PR DESCRIPTION
When relying on other ingress controller (nginx, traefik etc) it's useful to disable to CCM when provisioning the SKS cluster. Also added flag to remove the metrics server when not needed

Supported already by the CLI and the terraform resource but missing the this module